### PR TITLE
fix: symbol IMUA -> IM

### DIFF
--- a/config/wagmi.ts
+++ b/config/wagmi.ts
@@ -14,7 +14,7 @@ export const imua = {
   nativeCurrency: {
     decimals: 18,
     name: "Imua",
-    symbol: "IMUA",
+    symbol: "IM",
   },
   rpcUrls: {
     default: {


### PR DESCRIPTION
the correct symbol for imua token should be IM instead of IMUA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Imua network’s native currency symbol from “IMUA” to “IM,” ensuring the proper symbol appears in balances, transaction summaries, and network indicators.
* **Chores**
  * Updated network configuration to align with current Imua chain metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->